### PR TITLE
fix [builtin env]: assignment builtin node type; printing of env array when called with builtin "env"; assignment of tokentype in analyser

### DIFF
--- a/include/environment.h
+++ b/include/environment.h
@@ -26,7 +26,7 @@ extern "C" {
 forward declaration
 */
 typedef struct s_data t_data;
-
+typedef struct s_darray t_darray;
 /*
 enviromnemt list:
 - from the system I get the environ variable as a char **environ
@@ -34,7 +34,7 @@ enviromnemt list:
 */
 
 bool	update_env(t_data *data, const char *key, const char *value);
-void	print_env(t_data *data);
+int		print_env(t_darray *env_array);
 char	*mini_get_env(t_data *data, const char *key);
 char	*ft_strjoin3(const char *key, const char *mid, const char *value);
 

--- a/src/analyser.c
+++ b/src/analyser.c
@@ -11,6 +11,8 @@
 /* ************************************************************************** */
 
 #include "minishell.h"
+#include "analyser.h"
+#include "scanner.h"
 
 /*
 it checks if the terminal ast node is a builtin or a command
@@ -25,8 +27,7 @@ void	which_ast_node(t_ast_node *ast)
 	if (tokenlist == NULL || tokenlist->content == NULL)
 		return ;
 	token = (t_token *)tokenlist->content;
-	// debug("which_ast_node");
-	// print_ast(ast);
+	debug("which_ast_node");
 	// check if the token list is a builtin
 	// debug("token type: %d", (t_tokentype)(token->type));
 	// debug("lexeme %s", (char *)(token->lexeme));
@@ -64,6 +65,7 @@ void	expand_variable(t_data *data, t_token *token)
 			temp = NULL;
 		free(key);
 		token->lexeme = temp;
+		token->type = WORD;
 }
 
 void	read_exit_status(t_data *data, t_token *token)
@@ -74,12 +76,14 @@ void	read_exit_status(t_data *data, t_token *token)
 	temp = ft_itoa(data->exit_status);
 	free(token->lexeme);
 	token->lexeme = temp;
+	token->type = WORD;
 }
 
 void	extract_string(t_token *token)
 {
 	debug("extract_string");
 	ft_strlcpy(token->lexeme, (const char *)token->lexeme + 1, ft_strlen(token->lexeme) - 1);
+	token->type = WORD;
 }
 
 void	expand_string(t_data *data, t_token *token)
@@ -112,6 +116,7 @@ void	expand_string(t_data *data, t_token *token)
 		string_tokens = string_tokens->next;
 	}
 	ft_lstclear(&ptr_to_list, free_token); //free_token function is from scanner.h
+	token->type = WORD;
 }
 /*
 the function of the analyser is to walk on the tree and analyze and expand 
@@ -136,19 +141,18 @@ void analyse_expand(t_ast_node *ast, t_data *data)
 	debug("analyse expand");
 	debug("Received token type: %d ast node type: %d lexeme: %s", ((t_token *)token_list->content)->type, ast->type, ((t_token *)token_list->content)->lexeme);
 	// assignng a ast node type to the node
-	// which_ast_node(ast);
+	which_ast_node(ast);
 	while (token_list)
 	{
 		token = token_list->content;
-		if (token->type == VAR_EXPANSION && ast->type == NODE_TERMINAL)
+		if (token->type == VAR_EXPANSION)
 			expand_variable(data, token);
-		if (token->type == DOLLAR_QUESTION)
+		else if (token->type == DOLLAR_QUESTION)
 			read_exit_status(data, token);
-		if (token->type == S_QUOTED_STRING)
+		else if (token->type == S_QUOTED_STRING)
 			extract_string(token);
-		if (token->type == QUOTED_STRING)
+		else if (token->type == QUOTED_STRING)
 			expand_string(data, token);
-		token->type = WORD;
 		debug("Expanded token type: %d ast node type: %d lexeme: %s", token->type, ast->type, token->lexeme);
 		token_list = token_list->next;
 	}

--- a/src/builtins/builtins.c
+++ b/src/builtins/builtins.c
@@ -71,7 +71,7 @@ int    execute_builtin(t_list *tokenlist, t_data *data)
 	{
 		debug("false builtin\n");
 	}
-	if (ft_strncmp(data->input, "history -c", 11) == 0 || ft_strncmp(data->input, "history --clear", 16) == 0)
+	else if (ft_strncmp(data->input, "history -c", 11) == 0 || ft_strncmp(data->input, "history --clear", 16) == 0)
 	{
 		// debug("clearing history\n");
 		clear_hist_file();
@@ -83,31 +83,17 @@ int    execute_builtin(t_list *tokenlist, t_data *data)
 	}
 	else
 	{
-		debug("not an implemented builtin\n");
+		debug("not an implemented builtin");
 	}
 	return (status);
 }
 
 int	execute_env_builtin(t_data *data)
 {
-	t_darray	*env_array;
-	size_t		n_bytes;
 	int			error;
-	int			i;
 
-	debug("env builtin\n");
-	n_bytes = 0;
+	debug("env builtin");
 	error = 0;
-	i = 0;
-	env_array = data->env_arr;
-	while (env_array && env_array->contents && env_array->contents[i])
-	{
-		n_bytes = write(1, &(env_array->contents[i]), ft_strlen(env_array->contents[i]));
-		if (n_bytes < ft_strlen(env_array->contents[i]))
-			error = 1;
-		i++;
-	}
-	if (error == 1)
-		return (1);
-	return (0);
+	error = print_env(data->env_arr);
+	return (error);
 }

--- a/src/environment.c
+++ b/src/environment.c
@@ -12,6 +12,7 @@
 
 #include "minishell.h"
 #include "environment.h"
+#include "darray.h"
 
 bool update_env(t_data *data, const char *key, const char *value)
 {
@@ -59,18 +60,19 @@ bool update_env(t_data *data, const char *key, const char *value)
 /*
 this function will print the environment variables
 */
-void print_env(t_data *data)
+int	print_env(t_darray *env_arr)
 {
-	t_darray	*env_arr;
-	int			i;
+	int	i;
+	int	status;
 
 	i = 0;
-	env_arr = data->env_arr;
-	printf("printing env\n");
-	printf("{");
-	while (env_arr->contents[i] != NULL)
-		printf("\"%s\",", (char *)darray_get(env_arr, i++));
-	printf("}\n");
+	status = 0;
+	while (env_arr && env_arr->contents && env_arr->contents[i] != NULL)
+	{
+		if (printf("%s\n", (char *)darray_get(env_arr, i++)) < 0)
+			status = 1;
+	}
+	return (status);
 }
 
 /*


### PR DESCRIPTION
1. Corrected assignment of BUILTIN node type in analyser so that builtin functions actually get called in the executer
2. Fixed printing of environment array
3. adjusted assignement of tokentypes before and after expansion in analyser