### PR TITLE
FIX .gitignore: exclude executables (minishell, tests) and logs from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@
 
 # Executables
 minishell
-*_tests
+tests*/*_tests
 *.exe
 *.out
 *.app
@@ -43,7 +43,7 @@ minishell
 *.su
 *.idb
 *.pdb
-tests.log
+tests*/tests.log
 
 # Kernel Module Compile Results
 *.mod*


### PR DESCRIPTION
added minishell and test executables as well as test logs to .gitignore